### PR TITLE
change default `compressFormat` to brotli

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream/Decompressi
 
 This option is only valid when the `enableCompress` option is set to true.
 
-default: `"deflate-raw"`
+default: `"brotli"`
 
 type:
  - `"deflate-raw"`

--- a/src/options.ts
+++ b/src/options.ts
@@ -137,7 +137,7 @@ export function getInnerOptions(opt?: Options): InnerOptions {
                         ? compressFormatAlias[opt.compressFormat as CompressFormatAlias]
                         : String(opt.compressFormat) as CompressFormat
                 )
-                : "deflate-raw",
+                : "brotli",
 
         compressor:
             typeof opt.compressor == 'function' ? opt.compressor : undefined,

--- a/test/src/md-vue/options.vue
+++ b/test/src/md-vue/options.vue
@@ -27,7 +27,7 @@ If false, use Base64.<br>
 <p>Compress format.</p>
 <p><a target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream/DecompressionStream">https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream/DecompressionStream</a></p>
 <p>This option is only valid when the <code>enableCompress</code> option is set to true.</p>
-<p>default: <code>&quot;deflate-raw&quot;</code></p>
+<p>default: <code>&quot;brotli&quot;</code></p>
 <p>type:</p>
 <ul>
 <li><code>&quot;deflate-raw&quot;</code></li>

--- a/test/src/md/options.md
+++ b/test/src/md/options.md
@@ -42,7 +42,7 @@ https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream/Decompressi
 
 This option is only valid when the `enableCompress` option is set to true.
 
-default: `"deflate-raw"`
+default: `"brotli"`
 
 type:
  - `"deflate-raw"`


### PR DESCRIPTION
使用 brotli 可以获得更小的体积，构建后的文件体积从 deflate-raw 的 50 kB 缩小到 brotli 的 44 kB 。

计划等待 Chromium 支持，然后等待 2 年后合并。

参考：
  - WHATWG issue: https://github.com/whatwg/compression/issues/34
  - WHATWG PR: https://github.com/whatwg/compression/pull/80
  - Chromium issue: https://issues.chromium.org/issues/463397980
  - Browser compatibility: https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream#browser_compatibility

